### PR TITLE
[FIX] account_invoice_invoice2data: Recompute due_date based on date_…

### DIFF
--- a/account_invoice_invoice2data/wizards/wizard_invoice2data_import_state_apply.py
+++ b/account_invoice_invoice2data/wizards/wizard_invoice2data_import_state_apply.py
@@ -81,6 +81,8 @@ class WizardInvoice2dataImportStateApply(models.TransientModel):
             invoice_vals.update({"date_due": self.pdf_date_due})
 
         self.invoice_id.write(invoice_vals)
+        if not self.pdf_date_due:
+            self.invoice_id._onchange_payment_term_date_invoice()
 
         self.invoice_id.button_reset_tax_line_ids()
 


### PR DESCRIPTION
…invoice and payment_term_id if exist. This computation is done only in rare cases, when there is no explicit due_date in the PDF

https://erp.grap.coop/web#id=1149&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673